### PR TITLE
[Fix]contactのリレーションを追加

### DIFF
--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -1,2 +1,3 @@
 class Contact < ApplicationRecord
+  belongs_to :customer
 end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -15,7 +15,7 @@ ja:
         restrict_dependent_destroy:
           has_one: "%{record}が存在しているので削除できません"
           has_many: "%{record}が存在しているので削除できません"
-  # エラー分のカラム日本語化
+  # エラー分のカラムの日本語化
   activerecord:
     models:
       issue: "問題"


### PR DESCRIPTION
本番環境へマイグレーションファイルを反映する際にエラーが発生
ActiveRecord::StatementInvalid: Mysql2::Error: Can't DROP 'customer_id：integer'; check that column/key exists
contact.rbにcustomerとのリレーションが記載されていなかったので追記